### PR TITLE
Memory usage improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,17 +35,18 @@
   "devDependencies": {
     "@types/benchmark": "^1.0.31",
     "@types/jest": "^26.0.13",
+    "@types/lru-cache": "^5.1.1",
     "@types/node": "^12.0.0",
     "@types/uuid": "^8.3.4",
     "benchmark": "^2.1.4",
     "jest": "^26.4.2",
-    "node-abi": "^2.21.0",
     "prebuild": "^11.0.2",
     "prettier": "^2.0.5",
     "ts-node": "^9.0.0",
     "typescript": "^3.9.0"
   },
   "dependencies": {
+    "lru-cache": "^6.0.0",
     "node-addon-api": "^4.3.0",
     "prebuild-install": "^7.0.1",
     "uuid": "^8.3.2"

--- a/src/DesktopNotification.cpp
+++ b/src/DesktopNotification.cpp
@@ -14,91 +14,14 @@ using namespace Windows::Foundation;
 using namespace Wrappers;
 
 DesktopNotification::DesktopNotification(const std::wstring &id,
-                                         const std::wstring &title, const std::wstring &body,
-                                         const Napi::Function &callback)
-    : m_ref(0),
-      m_title(title),
+                                         const std::wstring &appID,
+                                         const std::wstring &title,
+                                         const std::wstring &body)
+    : m_title(title),
       m_body(body),
-      m_callback(Napi::ThreadSafeFunction::New(callback.Env(), callback, "Notification Callback", 0, 1)),
+      m_appID(appID),
       m_id(id)
 {
-    PWSTR appID;
-    HRESULT hr = GetCurrentProcessExplicitAppUserModelID(&appID);
-    if (!SUCCEEDED(hr))
-    {
-        DN_LOG_ERROR(L"Couldn't retrieve AUMID");
-        return;
-    }
-    else
-    {
-        m_appID = std::wstring(appID);
-        CoTaskMemFree(appID);
-    }
-}
-
-DesktopNotification::~DesktopNotification()
-{
-    m_callback.Release();
-}
-
-// DesktopToastActivatedEventHandler
-IFACEMETHODIMP DesktopNotification::Invoke(_In_ IToastNotification * /*sender*/,
-                                           _In_ IInspectable *args)
-{
-    IToastActivatedEventArgs *buttonReply = nullptr;
-    args->QueryInterface(&buttonReply);
-    if (buttonReply == nullptr)
-    {
-        DN_LOG_ERROR(L"args is not a IToastActivatedEventArgs");
-        return S_OK;
-    }
-
-    invokeJSCallback("click");
-
-    return S_OK;
-}
-
-// DesktopToastDismissedEventHandler
-IFACEMETHODIMP DesktopNotification::Invoke(_In_ IToastNotification * /* sender */,
-                                           _In_ IToastDismissedEventArgs *e)
-{
-    ToastDismissalReason tdr;
-    HRESULT hr = e->get_Reason(&tdr);
-    if (SUCCEEDED(hr))
-    {
-        switch (tdr)
-        {
-        case ToastDismissalReason_ApplicationHidden:
-            invokeJSCallback("hidden");
-            break;
-        case ToastDismissalReason_UserCanceled:
-            invokeJSCallback("dismissed");
-            break;
-        case ToastDismissalReason_TimedOut:
-            invokeJSCallback("timedout");
-            break;
-        }
-    }
-    return S_OK;
-}
-
-// DesktopToastFailedEventHandler
-IFACEMETHODIMP DesktopNotification::Invoke(_In_ IToastNotification * /* sender */,
-                                           _In_ IToastFailedEventArgs * /* e */)
-{
-    DN_LOG_ERROR(L"The toast encountered an error.");
-    invokeJSCallback("error");
-    return S_OK;
-}
-
-void DesktopNotification::invokeJSCallback(std::string eventName)
-{
-    auto cb = [eventName](Napi::Env env, Napi::Function jsCallback)
-    {
-        jsCallback.Call({Napi::String::New(env, eventName)});
-    };
-
-    m_callback.BlockingCall(cb);
 }
 
 // Set the values of each of the text nodes
@@ -116,14 +39,14 @@ HRESULT DesktopNotification::setTextValues()
     return setNodeValueString(HStringReference(m_body.c_str()).Get(), textNode.Get());
 }
 
-HRESULT DesktopNotification::startListeningEvents()
+HRESULT DesktopNotification::startListeningEvents(DesktopNotificationsManager *desktopNotificationsManager)
 {
     ComPtr<IToastNotification> toast = m_notification;
 
     // Register the event handlers
-    DN_RETURN_ON_ERROR(toast->add_Activated(this, &m_activatedToken));
-    DN_RETURN_ON_ERROR(toast->add_Dismissed(this, &m_dismissedToken));
-    DN_RETURN_ON_ERROR(toast->add_Failed(this, &m_failedToken));
+    DN_RETURN_ON_ERROR(toast->add_Activated(desktopNotificationsManager, &m_activatedToken));
+    DN_RETURN_ON_ERROR(toast->add_Dismissed(desktopNotificationsManager, &m_dismissedToken));
+    DN_RETURN_ON_ERROR(toast->add_Failed(desktopNotificationsManager, &m_failedToken));
 
     return S_OK;
 }
@@ -208,7 +131,8 @@ std::wstring DesktopNotification::formatAction(
 }
 
 // Create and display the toast
-HRESULT DesktopNotification::createToast(ComPtr<IToastNotificationManagerStatics> toastManager)
+HRESULT DesktopNotification::createToast(ComPtr<IToastNotificationManagerStatics> toastManager,
+                                         DesktopNotificationsManager *desktopNotificationsManager)
 {
     DN_RETURN_ON_ERROR(toastManager->GetTemplateContent(
         ToastTemplateType_ToastImageAndText02, &m_toastXml));
@@ -252,7 +176,7 @@ HRESULT DesktopNotification::createToast(ComPtr<IToastNotificationManagerStatics
     switch (setting)
     {
     case NotificationSetting_Enabled:
-        DN_RETURN_ON_ERROR(startListeningEvents());
+        DN_RETURN_ON_ERROR(startListeningEvents(desktopNotificationsManager));
         break;
     case NotificationSetting_DisabledForApplication:
         error = L"DisabledForApplication";

--- a/src/DesktopNotification.cpp
+++ b/src/DesktopNotification.cpp
@@ -51,17 +51,6 @@ HRESULT DesktopNotification::startListeningEvents(DesktopNotificationsManager *d
     return S_OK;
 }
 
-void DesktopNotification::stopListeningEvents()
-{
-    if (m_notification)
-    {
-        ComPtr<IToastNotification> toast = m_notification;
-        toast->remove_Activated(m_activatedToken);
-        toast->remove_Dismissed(m_dismissedToken);
-        toast->remove_Failed(m_failedToken);
-    }
-}
-
 HRESULT DesktopNotification::setNodeValueString(const HSTRING &inputString, IXmlNode *node)
 {
     ComPtr<IXmlText> inputText;

--- a/src/DesktopNotification.h
+++ b/src/DesktopNotification.h
@@ -2,109 +2,29 @@
 #include "DesktopNotificationsManager.h"
 #include <iostream>
 
-typedef ABI::Windows::Foundation::ITypedEventHandler<
-    ABI::Windows::UI::Notifications::ToastNotification *, ::IInspectable *>
-    DesktopToastActivatedEventHandler;
-typedef ABI::Windows::Foundation::ITypedEventHandler<
-    ABI::Windows::UI::Notifications::ToastNotification *,
-    ABI::Windows::UI::Notifications::ToastDismissedEventArgs *>
-    DesktopToastDismissedEventHandler;
-typedef ABI::Windows::Foundation::ITypedEventHandler<
-    ABI::Windows::UI::Notifications::ToastNotification *,
-    ABI::Windows::UI::Notifications::ToastFailedEventArgs *>
-    DesktopToastFailedEventHandler;
+class DesktopNotificationsManager;
 
-class DesktopNotification : public Microsoft::WRL::Implements<DesktopToastActivatedEventHandler,
-                                                              DesktopToastDismissedEventHandler,
-                                                              DesktopToastFailedEventHandler>
+class DesktopNotification
 {
 
 public:
     explicit DesktopNotification::DesktopNotification(const std::wstring &id,
-                                                      const std::wstring &title, const std::wstring &body,
-                                                      const Napi::Function &callback);
-    ~DesktopNotification();
-
-    // DesktopToastActivatedEventHandler
-    IFACEMETHODIMP Invoke(_In_ ABI::Windows::UI::Notifications::IToastNotification *sender,
-                          _In_ IInspectable *args);
-
-    // DesktopToastDismissedEventHandler
-    IFACEMETHODIMP Invoke(_In_ ABI::Windows::UI::Notifications::IToastNotification *sender,
-                          _In_ ABI::Windows::UI::Notifications::IToastDismissedEventArgs *e);
-
-    // DesktopToastFailedEventHandler
-    IFACEMETHODIMP Invoke(_In_ ABI::Windows::UI::Notifications::IToastNotification *sender,
-                          _In_ ABI::Windows::UI::Notifications::IToastFailedEventArgs *e);
-
-    // IUnknown
-    IFACEMETHODIMP_(ULONG)
-    AddRef()
-    {
-        return InterlockedIncrement(&m_ref);
-    }
-
-    IFACEMETHODIMP_(ULONG)
-    Release()
-    {
-        ULONG l = InterlockedDecrement(&m_ref);
-        if (l == 0)
-        {
-            delete this;
-        }
-        return l;
-    }
-
-    IFACEMETHODIMP QueryInterface(_In_ REFIID riid, _COM_Outptr_ void **ppv)
-    {
-        if (IsEqualIID(riid, IID_IUnknown))
-        {
-            *ppv = static_cast<IUnknown *>(static_cast<DesktopToastActivatedEventHandler *>(this));
-        }
-        else if (IsEqualIID(riid, __uuidof(DesktopToastActivatedEventHandler)))
-        {
-            *ppv = static_cast<DesktopToastActivatedEventHandler *>(this);
-        }
-        else if (IsEqualIID(riid, __uuidof(DesktopToastDismissedEventHandler)))
-        {
-            *ppv = static_cast<DesktopToastDismissedEventHandler *>(this);
-        }
-        else if (IsEqualIID(riid, __uuidof(DesktopToastFailedEventHandler)))
-        {
-            *ppv = static_cast<DesktopToastFailedEventHandler *>(this);
-        }
-        else
-        {
-            *ppv = nullptr;
-        }
-
-        if (*ppv)
-        {
-            reinterpret_cast<IUnknown *>(*ppv)->AddRef();
-            return S_OK;
-        }
-
-        return E_NOINTERFACE;
-    }
+                                                      const std::wstring &appID,
+                                                      const std::wstring &title,
+                                                      const std::wstring &body);
 
     std::wstring getID()
     {
         return m_id;
     }
 
-    std::wstring getAppID()
-    {
-        return m_appID;
-    }
-
     // Create and display the toast
-    HRESULT createToast(Microsoft::WRL::ComPtr<ABI::Windows::UI::Notifications::IToastNotificationManagerStatics> toastManager);
+    HRESULT createToast(Microsoft::WRL::ComPtr<ABI::Windows::UI::Notifications::IToastNotificationManagerStatics> toastManager,
+                        DesktopNotificationsManager *desktopNotificationsManager);
 
     void stopListeningEvents();
 
 private:
-    ULONG m_ref;
-    Napi::ThreadSafeFunction m_callback;
     std::wstring m_appID;
 
     std::wstring m_title;
@@ -116,11 +36,9 @@ private:
     Microsoft::WRL::ComPtr<ABI::Windows::UI::Notifications::IToastNotifier> m_notifier;
     Microsoft::WRL::ComPtr<ABI::Windows::UI::Notifications::IToastNotification> m_notification;
 
-    void invokeJSCallback(std::string eventName);
-
     // Set the values of each of the text nodes
     HRESULT setTextValues();
-    HRESULT startListeningEvents();
+    HRESULT startListeningEvents(DesktopNotificationsManager *desktopNotificationsManager);
     HRESULT setNodeValueString(const HSTRING &inputString, ABI::Windows::Data::Xml::Dom::IXmlNode *node);
     HRESULT addAttribute(const std::wstring &name, ABI::Windows::Data::Xml::Dom::IXmlNamedNodeMap *attributeMap);
     HRESULT addAttribute(const std::wstring &name, ABI::Windows::Data::Xml::Dom::IXmlNamedNodeMap *attributeMap,

--- a/src/DesktopNotification.h
+++ b/src/DesktopNotification.h
@@ -22,8 +22,6 @@ public:
     HRESULT createToast(Microsoft::WRL::ComPtr<ABI::Windows::UI::Notifications::IToastNotificationManagerStatics> toastManager,
                         DesktopNotificationsManager *desktopNotificationsManager);
 
-    void stopListeningEvents();
-
 private:
     std::wstring m_appID;
 

--- a/src/DesktopNotification.h
+++ b/src/DesktopNotification.h
@@ -22,6 +22,8 @@ public:
     HRESULT createToast(Microsoft::WRL::ComPtr<ABI::Windows::UI::Notifications::IToastNotificationManagerStatics> toastManager,
                         DesktopNotificationsManager *desktopNotificationsManager);
 
+    static std::string getNotificationIDFromToast(ABI::Windows::UI::Notifications::IToastNotification *toast);
+
 private:
     std::wstring m_appID;
 

--- a/src/DesktopNotificationsActionCenterActivator.h
+++ b/src/DesktopNotificationsActionCenterActivator.h
@@ -5,6 +5,8 @@
 #include <sstream>
 #include <wrl.h>
 
+#include "Utils.h"
+
 #define DN_WSTRINGIFY(X) L##X
 #define DN_STRINGIFY(X) DN_WSTRINGIFY(X)
 

--- a/src/DesktopNotificationsManager.cpp
+++ b/src/DesktopNotificationsManager.cpp
@@ -15,19 +15,11 @@ using namespace ABI::Windows::Data::Xml::Dom;
 using namespace Windows::Foundation;
 using namespace Wrappers;
 
-ComPtr<IToastNotificationHistory> DesktopNotificationsManager::getHistory()
-{
-    ComPtr<IToastNotificationManagerStatics2> toastStatics2;
-    if (DN_CHECK_RESULT(m_toastManager.As(&toastStatics2)))
-    {
-        ComPtr<IToastNotificationHistory> nativeHistory;
-        DN_CHECK_RESULT(toastStatics2->get_History(&nativeHistory));
-        return nativeHistory;
-    }
-    return {};
-}
-
-DesktopNotificationsManager::DesktopNotificationsManager(const std::wstring &toastActivatorClsid) : m_toastActivatorClsid(toastActivatorClsid)
+DesktopNotificationsManager::DesktopNotificationsManager(const std::wstring &toastActivatorClsid,
+                                                         Napi::Function &callback)
+    : m_ref(0),
+      m_toastActivatorClsid(toastActivatorClsid),
+      m_callback(Napi::ThreadSafeFunction::New(callback.Env(), callback, "Notification Callback", 0, 1))
 {
     {
         HRESULT hr = Windows::Foundation::Initialize(RO_INIT_MULTITHREADED);
@@ -58,6 +50,21 @@ DesktopNotificationsManager::DesktopNotificationsManager(const std::wstring &toa
         {
             DN_LOG_ERROR(L"DesktopNotificationsManager: Failed to set AUMID");
             return;
+        }
+    }
+
+    {
+        PWSTR appID;
+        HRESULT hr = GetCurrentProcessExplicitAppUserModelID(&appID);
+        if (!SUCCEEDED(hr))
+        {
+            DN_LOG_ERROR(L"Couldn't retrieve AUMID");
+            return;
+        }
+        else
+        {
+            m_appID = std::wstring(appID);
+            CoTaskMemFree(appID);
         }
     }
 
@@ -125,6 +132,8 @@ HRESULT DesktopNotificationsManager::RegisterClassObjects(const std::wstring &to
 
 DesktopNotificationsManager::~DesktopNotificationsManager()
 {
+    m_callback.Release();
+
     for (auto n : m_desktopNotifications)
     {
         closeNotification(n);
@@ -150,13 +159,25 @@ HRESULT DesktopNotificationsManager::UnregisterClassObjects()
     return hr;
 }
 
-HRESULT DesktopNotificationsManager::displayToast(const std::wstring &id,
-                                                  const std::wstring &title, const std::wstring &body,
-                                                  Napi::Function &callback)
+ComPtr<IToastNotificationHistory> DesktopNotificationsManager::getHistory()
 {
-    ComPtr<DesktopNotification> d(new DesktopNotification(id, title, body, callback));
+    ComPtr<IToastNotificationManagerStatics2> toastStatics2;
+    if (DN_CHECK_RESULT(m_toastManager.As(&toastStatics2)))
+    {
+        ComPtr<IToastNotificationHistory> nativeHistory;
+        DN_CHECK_RESULT(toastStatics2->get_History(&nativeHistory));
+        return nativeHistory;
+    }
+    return {};
+}
+
+HRESULT DesktopNotificationsManager::displayToast(const std::wstring &id,
+                                                  const std::wstring &title,
+                                                  const std::wstring &body)
+{
+    std::shared_ptr<DesktopNotification> d = std::make_shared<DesktopNotification>(id, m_appID, title, body);
     m_desktopNotifications.push_back(d);
-    return d->createToast(m_toastManager);
+    return d->createToast(m_toastManager, this);
 }
 
 bool DesktopNotificationsManager::closeToast(const std::wstring &id)
@@ -176,7 +197,7 @@ bool DesktopNotificationsManager::closeToast(const std::wstring &id)
     return false;
 }
 
-bool DesktopNotificationsManager::closeNotification(ComPtr<DesktopNotification> d)
+bool DesktopNotificationsManager::closeNotification(std::shared_ptr<DesktopNotification> d)
 {
     d->stopListeningEvents();
 
@@ -184,7 +205,7 @@ bool DesktopNotificationsManager::closeNotification(ComPtr<DesktopNotification> 
     {
         if (DN_CHECK_RESULT(history->RemoveGroupedTagWithId(
                 HStringReference(d->getID().c_str()).Get(), HStringReference(DN_GROUP_NAME).Get(),
-                HStringReference(d->getAppID().c_str()).Get())))
+                HStringReference(m_appID.c_str()).Get())))
         {
             return true;
         }
@@ -192,4 +213,66 @@ bool DesktopNotificationsManager::closeNotification(ComPtr<DesktopNotification> 
 
     DN_LOG_ERROR("Notification " << d->getID() << " does not exist");
     return false;
+}
+
+// DesktopToastActivatedEventHandler
+IFACEMETHODIMP DesktopNotificationsManager::Invoke(_In_ IToastNotification * /*sender*/,
+                                                   _In_ IInspectable *args)
+{
+    IToastActivatedEventArgs *buttonReply = nullptr;
+    args->QueryInterface(&buttonReply);
+    if (buttonReply == nullptr)
+    {
+        DN_LOG_ERROR(L"args is not a IToastActivatedEventArgs");
+        return S_OK;
+    }
+
+    invokeJSCallback("click", "REPLACE-ME");
+
+    return S_OK;
+}
+
+// DesktopToastDismissedEventHandler
+IFACEMETHODIMP DesktopNotificationsManager::Invoke(_In_ IToastNotification * /* sender */,
+                                                   _In_ IToastDismissedEventArgs *e)
+{
+    ToastDismissalReason tdr;
+    HRESULT hr = e->get_Reason(&tdr);
+    if (SUCCEEDED(hr))
+    {
+        switch (tdr)
+        {
+        case ToastDismissalReason_ApplicationHidden:
+            invokeJSCallback("hidden", "REPLACE-ME");
+            break;
+        case ToastDismissalReason_UserCanceled:
+            invokeJSCallback("dismissed", "REPLACE-ME");
+            break;
+        case ToastDismissalReason_TimedOut:
+            invokeJSCallback("timedout", "REPLACE-ME");
+            break;
+        }
+    }
+    return S_OK;
+}
+
+// DesktopToastFailedEventHandler
+IFACEMETHODIMP DesktopNotificationsManager::Invoke(_In_ IToastNotification * /* sender */,
+                                                   _In_ IToastFailedEventArgs * /* e */)
+{
+    DN_LOG_ERROR(L"The toast encountered an error.");
+    invokeJSCallback("error", "REPLACE-ME");
+    return S_OK;
+}
+
+void DesktopNotificationsManager::invokeJSCallback(std::string eventName,
+                                                   std::string notificationID)
+{
+    auto cb = [eventName, notificationID](Napi::Env env, Napi::Function jsCallback)
+    {
+        jsCallback.Call({Napi::String::New(env, eventName),
+                         Napi::String::New(env, notificationID)});
+    };
+
+    m_callback.BlockingCall(cb);
 }

--- a/src/DesktopNotificationsManager.cpp
+++ b/src/DesktopNotificationsManager.cpp
@@ -199,8 +199,6 @@ bool DesktopNotificationsManager::closeToast(const std::wstring &id)
 
 bool DesktopNotificationsManager::closeNotification(std::shared_ptr<DesktopNotification> d)
 {
-    d->stopListeningEvents();
-
     if (auto history = getHistory())
     {
         if (DN_CHECK_RESULT(history->RemoveGroupedTagWithId(
@@ -227,7 +225,13 @@ IFACEMETHODIMP DesktopNotificationsManager::Invoke(_In_ IToastNotification * /*s
         return S_OK;
     }
 
-    invokeJSCallback("click", "REPLACE-ME");
+    HSTRING dataArgs;
+    buttonReply->get_Arguments(&dataArgs);
+    std::wstring data = WindowsGetStringRawBuffer(dataArgs, nullptr);
+    const auto dataMap = Utils::splitData(data);
+    const auto notificationID = Utils::wideCharToUTF8(dataMap.at(L"notificationId"));
+
+    invokeJSCallback("click", notificationID);
 
     return S_OK;
 }

--- a/src/DesktopNotificationsManager.cpp
+++ b/src/DesktopNotificationsManager.cpp
@@ -237,9 +237,16 @@ IFACEMETHODIMP DesktopNotificationsManager::Invoke(_In_ IToastNotification * /*s
 }
 
 // DesktopToastDismissedEventHandler
-IFACEMETHODIMP DesktopNotificationsManager::Invoke(_In_ IToastNotification * /* sender */,
+IFACEMETHODIMP DesktopNotificationsManager::Invoke(_In_ IToastNotification *sender,
                                                    _In_ IToastDismissedEventArgs *e)
 {
+    const auto notificationID = DesktopNotification::getNotificationIDFromToast(sender);
+    if (notificationID == "")
+    {
+        DN_LOG_ERROR(L"Could not get notification ID from toast");
+        return S_OK;
+    }
+
     ToastDismissalReason tdr;
     HRESULT hr = e->get_Reason(&tdr);
     if (SUCCEEDED(hr))
@@ -247,25 +254,33 @@ IFACEMETHODIMP DesktopNotificationsManager::Invoke(_In_ IToastNotification * /* 
         switch (tdr)
         {
         case ToastDismissalReason_ApplicationHidden:
-            invokeJSCallback("hidden", "REPLACE-ME");
+            invokeJSCallback("hidden", notificationID);
             break;
         case ToastDismissalReason_UserCanceled:
-            invokeJSCallback("dismissed", "REPLACE-ME");
+            invokeJSCallback("dismissed", notificationID);
             break;
         case ToastDismissalReason_TimedOut:
-            invokeJSCallback("timedout", "REPLACE-ME");
+            invokeJSCallback("timedout", notificationID);
             break;
         }
     }
+
     return S_OK;
 }
 
 // DesktopToastFailedEventHandler
-IFACEMETHODIMP DesktopNotificationsManager::Invoke(_In_ IToastNotification * /* sender */,
-                                                   _In_ IToastFailedEventArgs * /* e */)
+IFACEMETHODIMP DesktopNotificationsManager::Invoke(_In_ IToastNotification *sender,
+                                                   _In_ IToastFailedEventArgs *e)
 {
+    const auto notificationID = DesktopNotification::getNotificationIDFromToast(sender);
+    if (notificationID == "")
+    {
+        DN_LOG_ERROR(L"Could not get notification ID from toast");
+        return S_OK;
+    }
+
     DN_LOG_ERROR(L"The toast encountered an error.");
-    invokeJSCallback("error", "REPLACE-ME");
+    invokeJSCallback("error", notificationID);
     return S_OK;
 }
 

--- a/src/DesktopNotificationsManager.h
+++ b/src/DesktopNotificationsManager.h
@@ -27,32 +27,112 @@
 using namespace Microsoft::WRL;
 using namespace ABI::Windows::Data::Xml::Dom;
 
-class DesktopNotificationsManager
+typedef ABI::Windows::Foundation::ITypedEventHandler<
+    ABI::Windows::UI::Notifications::ToastNotification *, ::IInspectable *>
+    DesktopToastActivatedEventHandler;
+typedef ABI::Windows::Foundation::ITypedEventHandler<
+    ABI::Windows::UI::Notifications::ToastNotification *,
+    ABI::Windows::UI::Notifications::ToastDismissedEventArgs *>
+    DesktopToastDismissedEventHandler;
+typedef ABI::Windows::Foundation::ITypedEventHandler<
+    ABI::Windows::UI::Notifications::ToastNotification *,
+    ABI::Windows::UI::Notifications::ToastFailedEventArgs *>
+    DesktopToastFailedEventHandler;
+
+class DesktopNotificationsManager : public Microsoft::WRL::Implements<DesktopToastActivatedEventHandler,
+                                                                      DesktopToastDismissedEventHandler,
+                                                                      DesktopToastFailedEventHandler>
 {
     friend class DesktopNotification;
 
 public:
-    DesktopNotificationsManager(const std::wstring &toastActivatorClsid);
+    DesktopNotificationsManager(const std::wstring &toastActivatorClsid,
+                                Napi::Function &callback);
     ~DesktopNotificationsManager();
 
     HRESULT displayToast(const std::wstring &id,
-                         const std::wstring &title, const std::wstring &body,
-                         Napi::Function &callback);
+                         const std::wstring &title, const std::wstring &body);
     bool closeToast(const std::wstring &id);
+
+    // DesktopToastActivatedEventHandler
+    IFACEMETHODIMP Invoke(_In_ ABI::Windows::UI::Notifications::IToastNotification *sender,
+                          _In_ IInspectable *args);
+
+    // DesktopToastDismissedEventHandler
+    IFACEMETHODIMP Invoke(_In_ ABI::Windows::UI::Notifications::IToastNotification *sender,
+                          _In_ ABI::Windows::UI::Notifications::IToastDismissedEventArgs *e);
+
+    // DesktopToastFailedEventHandler
+    IFACEMETHODIMP Invoke(_In_ ABI::Windows::UI::Notifications::IToastNotification *sender,
+                          _In_ ABI::Windows::UI::Notifications::IToastFailedEventArgs *e);
+
+    // IUnknown
+    IFACEMETHODIMP_(ULONG)
+    AddRef()
+    {
+        return InterlockedIncrement(&m_ref);
+    }
+
+    IFACEMETHODIMP_(ULONG)
+    Release()
+    {
+        ULONG l = InterlockedDecrement(&m_ref);
+        if (l == 0)
+        {
+            delete this;
+        }
+        return l;
+    }
+
+    IFACEMETHODIMP QueryInterface(_In_ REFIID riid, _COM_Outptr_ void **ppv)
+    {
+        if (IsEqualIID(riid, IID_IUnknown))
+        {
+            *ppv = static_cast<IUnknown *>(static_cast<DesktopToastActivatedEventHandler *>(this));
+        }
+        else if (IsEqualIID(riid, __uuidof(DesktopToastActivatedEventHandler)))
+        {
+            *ppv = static_cast<DesktopToastActivatedEventHandler *>(this);
+        }
+        else if (IsEqualIID(riid, __uuidof(DesktopToastDismissedEventHandler)))
+        {
+            *ppv = static_cast<DesktopToastDismissedEventHandler *>(this);
+        }
+        else if (IsEqualIID(riid, __uuidof(DesktopToastFailedEventHandler)))
+        {
+            *ppv = static_cast<DesktopToastFailedEventHandler *>(this);
+        }
+        else
+        {
+            *ppv = nullptr;
+        }
+
+        if (*ppv)
+        {
+            reinterpret_cast<IUnknown *>(*ppv)->AddRef();
+            return S_OK;
+        }
+
+        return E_NOINTERFACE;
+    }
 
 private:
     Microsoft::WRL::ComPtr<ABI::Windows::UI::Notifications::IToastNotificationHistory> getHistory();
 
     Microsoft::WRL::ComPtr<ABI::Windows::UI::Notifications::IToastNotificationManagerStatics> m_toastManager;
 
-    std::vector<Microsoft::WRL::ComPtr<DesktopNotification>> m_desktopNotifications;
+    std::vector<std::shared_ptr<DesktopNotification>> m_desktopNotifications;
 
     void SignalObjectCountZero();
     HRESULT RegisterClassObjects(const std::wstring &toastActivatorClsid);
     HRESULT UnregisterClassObjects();
-    bool closeNotification(Microsoft::WRL::ComPtr<DesktopNotification> d);
+    bool closeNotification(std::shared_ptr<DesktopNotification> d);
+    void invokeJSCallback(std::string eventName, std::string notificationID);
 
     // Identifiers of registered class objects. Used for unregistration.
     DWORD m_comCookies[1] = {0};
     const std::wstring m_toastActivatorClsid;
+    Napi::ThreadSafeFunction m_callback;
+    std::wstring m_appID;
+    ULONG m_ref;
 };

--- a/src/main.cc
+++ b/src/main.cc
@@ -30,7 +30,7 @@ namespace
       return env.Undefined();
     }
 
-    if (info.Length() < 1)
+    if (info.Length() < 2)
     {
       Napi::TypeError::New(env, "Wrong number of arguments").ThrowAsJavaScriptException();
       return env.Undefined();
@@ -42,8 +42,16 @@ namespace
       return env.Undefined();
     }
 
+    if (!info[1].IsFunction())
+    {
+      Napi::TypeError::New(env, "Callback must be a function.").ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+
     auto toastActivatorClsid = Utils::utf8ToWideChar(info[0].As<Napi::String>());
-    desktopNotificationsManager = std::make_shared<DesktopNotificationsManager>(toastActivatorClsid);
+    auto callback = info[1].As<Napi::Function>();
+
+    desktopNotificationsManager = std::make_shared<DesktopNotificationsManager>(toastActivatorClsid, callback);
 
     return info.Env().Undefined();
   }
@@ -64,7 +72,7 @@ namespace
       return env.Undefined();
     }
 
-    if (info.Length() < 4)
+    if (info.Length() < 3)
     {
       Napi::TypeError::New(env, "Wrong number of arguments").ThrowAsJavaScriptException();
       return env.Undefined();
@@ -88,18 +96,11 @@ namespace
       return env.Undefined();
     }
 
-    if (!info[3].IsFunction())
-    {
-      Napi::TypeError::New(env, "Callback must be a function.").ThrowAsJavaScriptException();
-      return env.Undefined();
-    }
-
     auto id = Utils::utf8ToWideChar(info[0].As<Napi::String>());
     auto title = Utils::utf8ToWideChar(info[1].As<Napi::String>());
     auto body = Utils::utf8ToWideChar(info[2].As<Napi::String>());
-    auto callback = info[3].As<Napi::Function>();
 
-    desktopNotificationsManager->displayToast(id, title, body, callback);
+    desktopNotificationsManager->displayToast(id, title, body);
 
     return env.Undefined();
   }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -15,33 +15,45 @@ namespace
 
 namespace Utils
 {
-  LPWSTR Utils::utf8ToWideChar(std::string utf8)
-  {
-    int wide_char_length = MultiByteToWideChar(CP_UTF8,
-                                               0,
-                                               utf8.c_str(),
-                                               -1,
-                                               nullptr,
-                                               0);
-    if (wide_char_length == 0)
+    LPWSTR Utils::utf8ToWideChar(std::string utf8)
     {
-      return nullptr;
+        int wide_char_length = MultiByteToWideChar(CP_UTF8,
+                                                   0,
+                                                   utf8.c_str(),
+                                                   -1,
+                                                   nullptr,
+                                                   0);
+        if (wide_char_length == 0)
+        {
+            return nullptr;
+        }
+
+        LPWSTR result = new WCHAR[wide_char_length];
+        if (MultiByteToWideChar(CP_UTF8,
+                                0,
+                                utf8.c_str(),
+                                -1,
+                                result,
+                                wide_char_length) == 0)
+        {
+            delete[] result;
+            return nullptr;
+        }
+
+        return result;
     }
 
-    LPWSTR result = new WCHAR[wide_char_length];
-    if (MultiByteToWideChar(CP_UTF8,
-                            0,
-                            utf8.c_str(),
-                            -1,
-                            result,
-                            wide_char_length) == 0)
+    std::string Utils::wideCharToUTF8(std::wstring wstr)
     {
-      delete[] result;
-      return nullptr;
+        if (wstr.empty())
+        {
+            return std::string();
+        }
+        int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
+        std::string strTo(size_needed, 0);
+        WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &strTo[0], size_needed, NULL, NULL);
+        return strTo;
     }
-
-    return result;
-  }
 
     std::unordered_map<std::wstring, std::wstring> splitData(const std::wstring &data)
     {

--- a/src/utils.h
+++ b/src/utils.h
@@ -16,6 +16,7 @@
 namespace Utils
 {
     LPWSTR utf8ToWideChar(std::string utf8);
+    std::string wideCharToUTF8(std::wstring wstr);
 
     std::unordered_map<std::wstring, std::wstring> splitData(const std::wstring &data);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -703,6 +703,11 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
+"@types/lru-cache@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"
+  integrity sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==
+
 "@types/node@*":
   version "14.6.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.4.tgz#a145cc0bb14ef9c4777361b7bbafa5cf8e3acb5a"
@@ -3342,13 +3347,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-node-abi@^2.21.0:
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.21.0.tgz#c2dc9ebad6f4f53d6ea9b531e7b8faad81041d48"
-  integrity sha512-smhrivuPqEM3H5LmnY3KU6HfYv0u4QklgAxfFyRNujKUzbUcYZ+Jc2EhukB9SRcD2VpqhxM7n/MIcp1Ua1/JMg==
-  dependencies:
-    semver "^5.4.1"
 
 node-abi@^3.0.0, node-abi@^3.3.0:
   version "3.7.0"


### PR DESCRIPTION
This PR makes a few changes around memory usage. But first, some context:
- Windows doesn't have a specific event when a notification is completely dismissed vs when it's hidden away from the user into the Action Center, so we're forced to keep around the click/event callbacks for as long as we can.
- In my initial implementation, the native side would store these callbacks for every notification.

The changes made in this PR are:
- Unifying all the events sent by the native side to only one callback that will receive both the event and the notificationID.
- The JS side will manage the callbacks with the consumer app. The less we do on native side, the less we need to port to other platforms, if we ever do that 😄 
- On this JS side, we will use a LRU cache to keep the number of in-memory notifications/callbacks under control.