### PR TITLE
v0.1.5

### DIFF
--- a/lib/desktop-notifications.ts
+++ b/lib/desktop-notifications.ts
@@ -1,11 +1,23 @@
 import { v4 as uuidv4 } from 'uuid'
 import * as LRUCache from 'lru-cache'
+import * as os from 'os'
+
+export function supportsNotifications() {
+  if (process.platform !== 'win32') {
+    return false
+  }
+
+  const versionComponents = os.release().split('.')
+  const majorVersion = parseInt(versionComponents[0], 10)
+
+  // Only Windows 10 and newer are supported
+  return majorVersion >= 10
+}
 
 // Windows-only for now
-const nativeModule =
-  process.platform === 'win32'
-    ? require('../../build/Release/desktop-notifications.node')
-    : null
+const nativeModule = supportsNotifications()
+  ? require('../../build/Release/desktop-notifications.node')
+  : null
 
 export function initializeNotifications(toastActivatorClsid: string) {
   nativeModule?.initializeNotifications(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop-notifications",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A simple and opinionated library for handling Windows notifications",
   "main": "dist/lib/index.js",
   "typings": "dist/lib/index.d.ts",


### PR DESCRIPTION
- Memory usage improvements #3
- A check to only enable `desktop-notifications` on Windows 10 and newer: #4