### PR TITLE
Fix `terminateNotifications`

### DIFF
--- a/sample-app/main.ts
+++ b/sample-app/main.ts
@@ -8,6 +8,7 @@ import {
   onNotificationEvent,
   requestNotificationsPermission,
   getNotificationSettingsUrl,
+  terminateNotifications,
 } from 'desktop-notifications'
 
 const createWindow = () => {
@@ -29,6 +30,9 @@ const createWindow = () => {
     })
   )
   win.webContents.openDevTools()
+  win.on('closed', () => {
+    terminateNotifications()
+  })
   return win
 }
 

--- a/src/mac/main_mac.mm
+++ b/src/mac/main_mac.mm
@@ -166,6 +166,13 @@ namespace
     return deferred.Promise();
   }
 
+  Napi::Value terminateNotifications(const Napi::CallbackInfo &info)
+  {
+    const Napi::Env &env = info.Env();
+    desktopNotificationsManager = nil;
+    return env.Undefined();
+  }
+
   Napi::Value closeNotification(const Napi::CallbackInfo &info)
   {
     const Napi::Env &env = info.Env();
@@ -254,9 +261,9 @@ namespace
   Napi::Object Init(Napi::Env env, Napi::Object exports)
   {
     exports.Set(Napi::String::New(env, "initializeNotifications"), Napi::Function::New(env, initializeNotifications));
+    exports.Set(Napi::String::New(env, "terminateNotifications"), Napi::Function::New(env, terminateNotifications));
     exports.Set(Napi::String::New(env, "showNotification"), Napi::Function::New(env, showNotification));
     exports.Set(Napi::String::New(env, "closeNotification"), Napi::Function::New(env, closeNotification));
-    exports.Set(Napi::String::New(env, "requestNotificationsPermission"), Napi::Function::New(env, requestNotificationsPermission));
     exports.Set(Napi::String::New(env, "getNotificationsPermission"), Napi::Function::New(env, getNotificationsPermission));
     exports.Set(Napi::String::New(env, "requestNotificationsPermission"), Napi::Function::New(env, requestNotificationsPermission));
 

--- a/src/win/DesktopNotificationsManager.cpp
+++ b/src/win/DesktopNotificationsManager.cpp
@@ -133,11 +133,6 @@ HRESULT DesktopNotificationsManager::RegisterClassObjects(const std::wstring &to
 DesktopNotificationsManager::~DesktopNotificationsManager()
 {
     m_callback.Release();
-
-    for (auto n : m_desktopNotifications)
-    {
-        closeNotification(n);
-    }
     m_desktopNotifications.clear();
 
     UnregisterClassObjects();


### PR DESCRIPTION
This PR addresses two issues related to `terminateNotifications`:
1. After the many API changes (or change attempts) in #13, I removed the `terminateNotifications` implementation for macOS.
2. I noticed `terminateNotifications` still removed any pending notifications on Windows, which defeats the purpose of some of the changes in #13 about handling notifications from previous app sessions.

These changes are needed in order to unblock https://github.com/desktop/desktop/pull/14733, which basically fixes an issue where a process is not closed along with the rest of the app on Windows 10 (but not 11) due to our notifications code (probably, the COM server used to handle the notifications).