### PR TITLE
Release 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop-notifications",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A simple and opinionated library for handling Windows notifications",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sample-app/yarn.lock
+++ b/sample-app/yarn.lock
@@ -922,7 +922,7 @@ depd@~1.1.2:
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
 desktop-notifications@../:
-  version "0.2.0"
+  version "0.2.2"
   dependencies:
     node-addon-api "^5.0.0"
     prebuild-install "^7.0.1"


### PR DESCRIPTION
- Implements `terminateNotifications` on macOS, and prevents it from removing pending notifications on Windows #20 