### PR TITLE
Only support the Windows 10 Creators Update and newer

### DIFF
--- a/lib/notification-support.ts
+++ b/lib/notification-support.ts
@@ -27,11 +27,19 @@ function supportsDarwinNotifications() {
 }
 
 function supportsWindowsNotifications() {
+  // The Windows Notification APIs we use are only available on Windows 10+, and
+  // some of them are limited before the Creators Update (build 15063).
+  const CreatorsUpdateBuildNumber = 15063
+
   const versionComponents = os.release().split('.')
   const majorVersion = parseInt(versionComponents[0], 10)
+  const buildNumber =
+    versionComponents.length >= 3
+      ? parseInt(versionComponents[2], 10)
+      : CreatorsUpdateBuildNumber
 
-  // Only Windows 10 and newer are supported
-  return majorVersion >= 10
+  // Only Windows 10 (15063) and newer are supported
+  return majorVersion >= 10 && buildNumber >= CreatorsUpdateBuildNumber
 }
 
 /**

--- a/lib/notification-support.ts
+++ b/lib/notification-support.ts
@@ -29,6 +29,7 @@ function supportsDarwinNotifications() {
 function supportsWindowsNotifications() {
   // The Windows Notification APIs we use are only available on Windows 10+, and
   // some of them are limited before the Creators Update (build 15063).
+  // See: https://docs.microsoft.com/en-us/uwp/api/windows.ui.notifications.toastnotification.tag?view=winrt-22621#remarks
   const CreatorsUpdateBuildNumber = 15063
 
   const versionComponents = os.release().split('.')


### PR DESCRIPTION
After investigating some issues in GitHub Desktop running on Windows Server 2016 (desktop/desktop#14714) it seems there are some limitations in Windows 10 prior to the Creators Update regarding the notifications API: https://docs.microsoft.com/en-us/uwp/api/windows.ui.notifications.toastnotification.tag?view=winrt-22621#remarks

I've changed a few things but it seems there is an important limitation in the notification payload, which makes it difficult for us to implement notifications as we'd like them.

Because of that, we're gonna support notifications from this `desktop-notifications` library on Windows 10 Creators Update and newer, while previous versions will rely on the HTML notifications API (just like W7 and W8 do nowadays, without the improvements from #13).